### PR TITLE
Remove clearing temp folder

### DIFF
--- a/extra/scripts/windows-compress.ps1
+++ b/extra/scripts/windows-compress.ps1
@@ -20,11 +20,6 @@ wevtutil el | Foreach-Object {wevtutil cl "$_"}
 dism /online /cleanup-image /StartComponentCleanup /ResetBase
 dism /online /cleanup-Image /SPSuperseded
 
-# Remove leftovers from deploy
-if (Test-Path -Path c:\Windows\Temp ) {
-    Remove-Item c:\Windows\Temp\* -Recurse -Force
-}
-
 # optimize disk
 Write-Output "Phase-5c.2: Defragging.."
 if (Get-Command Optimize-Volume -ErrorAction SilentlyContinue) {


### PR DESCRIPTION
The problem with this line is that packer runs the powershell scripts underneath C:\Windows\Temp\*, and clearing that folder while running a powershell task will fail.

![image](https://user-images.githubusercontent.com/2729151/117882336-392cf780-b278-11eb-9870-b9b948e30fd3.png)
